### PR TITLE
use AWS Region from the set secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ This is an example of how to configure and deploy a development environment that
         AWS_SECRET_ACCESS_KEY: The Secret Acces Key of your IAM user
         AWS_REGION: The region in AWS you would like to use for the external resources
 
+Make sure this AWS user has permissions to create, read from, and delete the following AWS services:
 
-> If you are using Okteto Self-Hosted, you can configure your instance to use an AWS role instead of using an Acess Key and Secret Access Key.
+- SQS Queues
+- S3 Buckets
+
+> Alternatively if you are using Okteto Self-Hosted, you can configure your instance to use an AWS role instead of using an Acess Key and Secret Access Key.
 
 Once this is configured, anyone with access to your Okteto instance will be able to deploy an development environment automatically, including the required cloud infrastructure.
 

--- a/okteto.yaml
+++ b/okteto.yaml
@@ -21,7 +21,7 @@ deploy:
     command: |
       set -e
       resourceName="${OKTETO_NAMESPACE}-oktacoshop"
-      region=us-west-2
+      region=$AWS_REGION
       
       export KUBE_CONFIG_PATH="$KUBECONFIG"
       export KUBE_NAMESPACE=$OKTETO_NAMESPACE
@@ -65,7 +65,7 @@ destroy:
     command: |
       set -e
       resourceName="${OKTETO_NAMESPACE}-oktacoshop"
-      region=us-west-2
+      region=$AWS_REGION
       
       export KUBE_CONFIG_PATH="$KUBECONFIG"
       export KUBE_NAMESPACE=$OKTETO_NAMESPACE


### PR DESCRIPTION
If we currently set the `AWS_REGION` Okteto Secret to anything other than `us-west-2`, the app will not function properly. This is because the Queue will always be created in the `us-west-2` region, while the command to create the secret – which the application code relies on – uses the value of the region from the `AWS_REGION` Okteto Secret. 
```
  - name: Create the AWS secret
    command: |
      kubectl create secret generic aws-credentials --save-config --dry-run=client --from-literal=AWS_REGION=$AWS_REGION --from-literal=AWS_DEFAULT_REGION=$AWS_REGION --from-literal=AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY --from-literal=AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -o yaml | kubectl apply -f -
```
By making this change, the Queue will be created in the correct region as specified by the `AWS_REGION` Okteto Secret.