### PR TITLE
[OKTACO-1-update-to-node-20] Update to Node 20

### DIFF
--- a/menu/Dockerfile
+++ b/menu/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-slim
+FROM node:20-buster-slim
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
With this change, the menu service and the corresponding development environment will be using the [Node 20 buster-slim](https://github.com/nodejs/docker-node/blob/62c2e3cfb17ba8d9167b0daebbff9ea5ecaef6e4/20/buster-slim/Dockerfile)  image from Dockerhub.